### PR TITLE
Add simple liquid simulation web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,11 @@
 # 🌊 Liquid Simulation Web App
 
-This is a real-time liquid simulation built for the browser using WebGL and JavaScript. It demonstrates fluid dynamics through GPU-accelerated rendering.
+This project is a simple liquid simulation written in plain JavaScript. It features interactive sliders so you can tweak the physics in real time.
 
 ## 🚀 Features
-
-- Real-time particle-based fluid simulation
-- Responsive design for web
-- Adjustable parameters like viscosity and velocity
-
-## 🛠️ Tech Stack
-
-- HTML5 + CSS3
-- JavaScript
-- WebGL / Three.js
+- Real-time 2D fluid simulation
+- Adjustable parameters for diffusion, viscosity, time step and curl
+- Drag the mouse on the canvas to disturb the liquid
 
 ## 📦 Getting Started
-
-```bash
-npm install
-npm run dev
-
+Simply open `index.html` in a modern web browser. No build step or additional dependencies are required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Liquid Simulation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="app">
+    <div id="controls">
+      <h2>Controls</h2>
+      <label>Density Dissipation
+        <input id="density" type="range" min="0" max="1" step="0.01" value="0.98">
+      </label>
+      <label>Velocity Dissipation
+        <input id="velocity" type="range" min="0" max="1" step="0.01" value="0.99">
+      </label>
+      <label>Pressure Dissipation
+        <input id="pressure" type="range" min="0" max="1" step="0.01" value="0.8">
+      </label>
+      <label>Curl
+        <input id="curl" type="range" min="0" max="50" step="0.1" value="30">
+      </label>
+    </div>
+    <canvas id="canvas"></canvas>
+  </div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,174 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+let width, height, resolution = 64;
+let size = (resolution + 2) * (resolution + 2);
+
+// simulation parameters
+let dt = 0.1;
+let diffusion = 0.0;
+let viscosity = 0.0;
+let curl = 30.0;
+
+let dens = new Float32Array(size);
+let densPrev = new Float32Array(size);
+let u = new Float32Array(size);
+let v = new Float32Array(size);
+let uPrev = new Float32Array(size);
+let vPrev = new Float32Array(size);
+
+function IX(x, y) { return x + (resolution + 2) * y; }
+
+function reset() {
+  width = canvas.clientWidth;
+  height = canvas.clientHeight;
+  canvas.width = width;
+  canvas.height = height;
+}
+window.addEventListener('resize', reset);
+reset();
+
+function addSource(x, s) {
+  for (let i = 0; i < size; i++) x[i] += dt * s[i];
+}
+
+function setBnd(b, x) {
+  for (let i = 1; i <= resolution; i++) {
+    x[IX(0, i)] = b === 1 ? -x[IX(1, i)] : x[IX(1, i)];
+    x[IX(resolution + 1, i)] = b === 1 ? -x[IX(resolution, i)] : x[IX(resolution, i)];
+    x[IX(i, 0)] = b === 2 ? -x[IX(i, 1)] : x[IX(i, 1)];
+    x[IX(i, resolution + 1)] = b === 2 ? -x[IX(i, resolution)] : x[IX(i, resolution)];
+  }
+  x[IX(0, 0)] = 0.5 * (x[IX(1, 0)] + x[IX(0, 1)]);
+  x[IX(0, resolution + 1)] = 0.5 * (x[IX(1, resolution + 1)] + x[IX(0, resolution)]);
+  x[IX(resolution + 1, 0)] = 0.5 * (x[IX(resolution, 0)] + x[IX(resolution + 1, 1)]);
+  x[IX(resolution + 1, resolution + 1)] = 0.5 * (x[IX(resolution, resolution + 1)] + x[IX(resolution + 1, resolution)]);
+}
+
+function linSolve(b, x, x0, a, c) {
+  for (let k = 0; k < 20; k++) {
+    for (let i = 1; i <= resolution; i++) {
+      for (let j = 1; j <= resolution; j++) {
+        x[IX(i, j)] = (x0[IX(i, j)] + a*(x[IX(i-1, j)] + x[IX(i+1, j)] + x[IX(i, j-1)] + x[IX(i, j+1)])) / c;
+      }
+    }
+    setBnd(b, x);
+  }
+}
+
+function diffuse(b, x, x0, diff) {
+  const a = dt * diff * resolution * resolution;
+  linSolve(b, x, x0, a, 1 + 4 * a);
+}
+
+function advect(b, d, d0, u, v) {
+  let dt0 = dt * resolution;
+  for (let i = 1; i <= resolution; i++) {
+    for (let j = 1; j <= resolution; j++) {
+      let x = i - dt0 * u[IX(i, j)];
+      let y = j - dt0 * v[IX(i, j)];
+      if (x < 0.5) x = 0.5; if (x > resolution + 0.5) x = resolution + 0.5;
+      let i0 = Math.floor(x); let i1 = i0 + 1;
+      if (y < 0.5) y = 0.5; if (y > resolution + 0.5) y = resolution + 0.5;
+      let j0 = Math.floor(y); let j1 = j0 + 1;
+      let s1 = x - i0; let s0 = 1 - s1; let t1 = y - j0; let t0 = 1 - t1;
+      d[IX(i, j)] = s0 * (t0 * d0[IX(i0, j0)] + t1 * d0[IX(i0, j1)]) + s1 * (t0 * d0[IX(i1, j0)] + t1 * d0[IX(i1, j1)]);
+    }
+  }
+  setBnd(b, d);
+}
+
+function project(u, v, p, div) {
+  for (let i = 1; i <= resolution; i++) {
+    for (let j = 1; j <= resolution; j++) {
+      div[IX(i, j)] = -0.5*(u[IX(i+1, j)] - u[IX(i-1, j)] + v[IX(i, j+1)] - v[IX(i, j-1)]) / resolution;
+      p[IX(i, j)] = 0;
+    }
+  }
+  setBnd(0, div); setBnd(0, p);
+  linSolve(0, p, div, 1, 4);
+  for (let i = 1; i <= resolution; i++) {
+    for (let j = 1; j <= resolution; j++) {
+      u[IX(i, j)] -= 0.5 * resolution * (p[IX(i+1, j)] - p[IX(i-1, j)]);
+      v[IX(i, j)] -= 0.5 * resolution * (p[IX(i, j+1)] - p[IX(i, j-1)]);
+    }
+  }
+  setBnd(1, u); setBnd(2, v);
+}
+
+function velStep(u, v, u0, v0) {
+  addSource(u, u0); addSource(v, v0);
+  [u0, u] = [u, u0]; diffuse(1, u, u0, viscosity); [v0, v] = [v, v0]; diffuse(2, v, v0, viscosity);
+  project(u, v, u0, v0);
+  [u0, u] = [u, u0]; [v0, v] = [v, v0];
+  advect(1, u, u0, u0, v0); advect(2, v, v0, u0, v0);
+  project(u, v, u0, v0);
+}
+
+function densStep(x, x0, u, v) {
+  addSource(x, x0);
+  [x0, x] = [x, x0]; diffuse(0, x, x0, diffusion);
+  [x0, x] = [x, x0]; advect(0, x, x0, u, v);
+}
+
+function renderDens(d) {
+  let img = ctx.getImageData(0, 0, width, height);
+  for (let i = 1; i <= resolution; i++) {
+    for (let j = 1; j <= resolution; j++) {
+      let densVal = d[IX(i, j)];
+      let color = Math.min(255, densVal * 255);
+      for (let x = 0; x < width / resolution; x++) {
+        for (let y = 0; y < height / resolution; y++) {
+          let px = Math.floor((i - 1) * width / resolution + x);
+          let py = Math.floor((j - 1) * height / resolution + y);
+          let idx = (py * width + px) * 4;
+          img.data[idx] = color;
+          img.data[idx + 1] = 100;
+          img.data[idx + 2] = 255 - color;
+          img.data[idx + 3] = 255;
+        }
+      }
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+}
+
+function step() {
+  velStep(u, v, uPrev, vPrev);
+  densStep(dens, densPrev, u, v);
+  renderDens(dens);
+  // reset prev arrays
+  uPrev.fill(0); vPrev.fill(0); densPrev.fill(0);
+  requestAnimationFrame(step);
+}
+
+let mouseDown = false;
+canvas.addEventListener('mousedown', () => mouseDown = true);
+window.addEventListener('mouseup', () => mouseDown = false);
+canvas.addEventListener('mousemove', (e) => {
+  if (!mouseDown) return;
+  const rect = canvas.getBoundingClientRect();
+  const x = ((e.clientX - rect.left) / rect.width) * resolution + 1;
+  const y = ((e.clientY - rect.top) / rect.height) * resolution + 1;
+  const i = Math.floor(x); const j = Math.floor(y);
+  if (i > 0 && i <= resolution && j > 0 && j <= resolution) {
+    densPrev[IX(i, j)] = 10;
+    uPrev[IX(i, j)] = (x - i) * curl;
+    vPrev[IX(i, j)] = (y - j) * curl;
+  }
+});
+
+// sliders
+document.getElementById('density').addEventListener('input', (e) => {
+  diffusion = 1 - parseFloat(e.target.value);
+});
+document.getElementById('velocity').addEventListener('input', (e) => {
+  viscosity = 1 - parseFloat(e.target.value);
+});
+document.getElementById('pressure').addEventListener('input', (e) => {
+  dt = parseFloat(e.target.value);
+});
+document.getElementById('curl').addEventListener('input', (e) => {
+  curl = parseFloat(e.target.value);
+});
+
+step();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,28 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: #111;
+  color: #eee;
+}
+
+#app {
+  display: flex;
+  height: 100vh;
+}
+
+#controls {
+  width: 200px;
+  padding: 1rem;
+  background: #222;
+}
+
+#controls label {
+  display: block;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+#canvas {
+  flex: 1;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add a demo single-page liquid simulation using a small CPU solver
- add sliders for density/velocity diffusion, pressure, and curl
- document how to run the page in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b53fc37d08328a61bd6502e5045c0